### PR TITLE
More Object Manipulation Methods, gulpfile Rewrite, Evaluate Function & More

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+# Tests new pull requests for any bugs.
+name: Mocha Testing
+on: pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # Bring in commits proposed in the pull request.
+    - uses: actions/checkout@v1
+      # Setup node environment with dependencies from package.json.
+    - name: Setup Node Modules
+      run: npm install
+      # Test the new commits and ensure they don't introduce any bugs.
+    - name: Run Tests With Mocha
+      run: ./node_modules/.bin/mocha

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ jobs:
       # Setup node environment with dependencies from package.json.
     - name: Setup Node Modules
       run: npm install
+      # Build the project.
+    - name: Build Project
+      run: ./node_modules/.bin/gulp compile
       # Test the new commits and ensure they don't introduce any bugs.
     - name: Run Tests With Mocha
       run: ./node_modules/.bin/mocha

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 # Ignore development files.
 test/
+.github/
 gulpfile.js

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Usage
 Simply import the file that corresponds to your environments module manager and enjoy extended prototypes and types in TypeScript.
 
 ```TypeScript
-import "./tools";
+import "daniis-tools";
 
 let numberNames: Of<number> = {"one": 1, "two": 2, "three": 3};
 ```
 ```JavaScript
-require("./tools");
+require("daniis-tools");
 
 let strings = {
   "en": "You have ${count} new messages.",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,26 +1,2 @@
-const [{src, dest}, fs, ts, rename, compress, merge, filter] =
-  ["!gulp", "!fs", "typescript", "rename", "minify", "!merge-stream", "filter"]
-    .map(i => i.startsWith("!") ? i.substr(1) : `gulp-${i}`).map(require);
-
-const requiredFolders = ["dist"];
-
-function ensureFolders() {
-  requiredFolders.forEach(dir => fs.existsSync(dir) ? null : fs.mkdirSync(dir));
-}
-
-module.exports = {
-  compile() {
-    ensureFolders();
-
-    const modSys = {"esmodule": "ESNext", "commonjs": "CommonJS"};
-    const dTsFilter = filter(["**", "!**/*.d.ts"], {"restore": true});
-    const get = (mod) => ts.createProject("tsconfig.json", {"module": modSys[mod]});
-    const applyTs = (pipe, mod) => pipe.pipe(get(mod)()).pipe(dTsFilter).pipe(rename(p => p.basename = mod + "-" + p.basename));
-    const applyCompress = (pipe, opts) => pipe.pipe(compress(opts));
-
-    let out = [src("./src/*.ts")];
-    out = out.map(i => [applyTs(i, "esmodule"), applyTs(i, "commonjs")]).flat();
-    out = out.map(i => [i, applyCompress(i, {"ext": {"min": "-min.js"}, "preserveComments": "some"})]).flat();
-    return merge(...out, dTsFilter.restore).pipe(dest("./dist/"));
-  }
-}
+const requireEs = require("esm")(module);
+module.exports = requireEs("./gulpfile.mjs");

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -1,0 +1,33 @@
+import Gulp from "gulp";
+import ts from "gulp-typescript";
+import minify from "gulp-minify";
+import rename from "gulp-rename";
+import filter from "gulp-filter";
+import merge from "merge-stream";
+
+const {src, dest} = Gulp;
+const moduleGoals = {"esmodule": "ESNext", "commonjs": "CommonJS"};
+const optsCompress = {"ext": {"min": "-min.js"}, "preserveComments": "some"};
+
+function mapObject(object, func) {
+  return Object.fromEntries(Object.entries(object).map((item, index) => [item[0], func(item, index, object)]));
+}
+
+function mapObjectToArray(object, func) {
+  return Object.entries(object).map((item, index) => func(item, index, object));
+}
+
+export function compile() {
+  const tsProjects = mapObject(moduleGoals, ([key, value]) =>
+    ts.createProject("tsconfig.json", {"module": value})());
+  const dtsFilter = filter(["**", "!**/*.d.ts"], {"restore": true});
+  const compile = (pipe, mod) => pipe.pipe(tsProjects[mod]).pipe(dtsFilter)
+    .pipe(rename(path => path.basename = mod + "-" + path.basename));
+  const compress = pipe => pipe.pipe(minify(optsCompress));
+    
+  const source = src("./src/**/*.ts");
+  const stage1 = mapObjectToArray(tsProjects, ([key]) => compile(source, key)).flat();
+  const stage2 = stage1.map(pipe => compress(pipe)).flat();
+  const stage3 = [stage2[0].pipe(dtsFilter.restore), stage2.slice(1)];
+  return merge(...stage3).pipe(dest("./dist/"));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4178,11 +4178,6 @@
         "vinyl": "^2.0.0"
       }
     },
-    "vm2": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.8.4.tgz",
-      "integrity": "sha512-5HThl+RBO/pwE9SF0kM4nLrpq5vXHBNk4BMX27xztvl0j1RsZ4/PMVJAu9rM9yfOtTo5KroL7XNX3031ExleSw=="
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -899,6 +899,12 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4172,6 +4172,11 @@
         "vinyl": "^2.0.0"
       }
     },
+    "vm2": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.8.4.tgz",
+      "integrity": "sha512-5HThl+RBO/pwE9SF0kM4nLrpq5vXHBNk4BMX27xztvl0j1RsZ4/PMVJAu9rM9yfOtTo5KroL7XNX3031ExleSw=="
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^12.12.14",
+    "esm": "^3.2.25",
     "gulp": "^4.0.2",
     "gulp-filter": "^6.0.0",
     "gulp-minify": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
   "author": "Daniel Conley",
   "license": "GPL-3.0",
   "keywords": [
-    "tools", "types", "prototype", "extension", "methods", "utility", "util"
+    "tools",
+    "types",
+    "prototype",
+    "extension",
+    "methods",
+    "utility",
+    "util"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "tools",
     "types",
     "prototype",
-    "extension",
     "methods",
     "utility",
     "util"

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -328,8 +328,10 @@ declare global {
     every<T, V, TH = any>(object: Of<V> & T, callback: Mapper<Entry<V>, boolean, T, TH>, thisArg?: TH): boolean;
     filter<T, V, TH = any>(object: Of<V> & T, callback: Mapper<Entry<V>, boolean, T, TH>, thisArg?: TH): Of<V>;
     forEach<T, V, TH = any>(object: Of<V> & T, callback: Mapper<Entry<V>, void, T, TH>, thisArg?: TH): void;
+    map<T, V, R = void, TH = any>(object: Of<V> & T, callback: Mapper<Entry<V>, boolean, T, TH>, thisArg?: TH): Of<R>;
     reduce<T, V, R>(object: Of<V> & T, callback: Reducer<Entry<V>, R, T>): T | R;
     reduce<T, V, R, I = R>(object: Of<V> & T, callback: Reducer<Entry<V>, R, T, I>, initial: I): R | I;
+    some<T, V, TH = any>(object: Of<V> & T, callback: Mapper<Entry<V>, boolean, T, TH>, thisArg?: TH): boolean;
   
     getType(item: any): string;
     objectHasOwnProperty(object: any, property: Key): boolean;
@@ -442,18 +444,40 @@ defineProperties(Object, {
     return Object.assign(new Construct(), item);
   },
 
-  every<Type, Values, This = any>(this: ObjectConstructor, object: Of<Values> & Type, callback: Mapper<Entry<Values>, boolean, Type, This>, thisArg?: This): boolean {
-    return this.entries(object).every((a, i) => callback.call(thisArg, a, i, object));
+  every<T, V, TH = any>(object: Of<V> & T,
+      callback: Mapper<Entry<V>, boolean, T, TH>, thisArg?: TH): boolean {
+    return Object.entries(object)
+      .every((item, ind) => callback.call(thisArg, item, ind, object));
   },
 
-  filter<Type, Values, This = any>(this: ObjectConstructor, object: Of<Values> & Type, callback: Mapper<Entry<Values>, boolean, Type, This>, thisArg?: This): Of<Values> {
-    return this.fromEntries(this.entries(object).filter((a, i) => callback.call(thisArg, a, i, object)));
+  filter<T, V, TH = any>(object: Of<V> & T,
+      callback: Mapper<Entry<V>, boolean, T, TH>, thisArg?: TH): Of<V> {
+    return Object.fromEntries(Object.entries(object)
+      .filter((item, ind) => callback.call(thisArg, item, ind, object)));
   },
 
-  forEach<V, T, TH = any>(object: Of<V> & T,
+  forEach<T, V, TH = any>(object: Of<V> & T,
       callback: Mapper<Entry<V>, void, T, TH>, thisArg: TH): void {
     return Object.entries(object)
       .forEach((item, ind) => callback.call(thisArg, item, ind, object));
+  },
+
+  map<T, V, R = void, TH = any>(object: Of<V> & T,
+      callback: Mapper<Entry<V>, R, T, TH>, thisArg: TH) {
+    return Object.fromEntries(Object.entries(object)
+      .map((item, ind) => callback.call(thisArg, item, ind, object)));
+  },
+
+  reduce<T, V, R, I>(object: Of<V> & T, callback: Reducer<Entry<V>, R, T, I>,
+      initial?: I) {
+    return Object.entries(object).reduce<R, I>((acc, item, ind) =>
+      callback(acc, item, ind, object), initial);
+  },
+
+  some<T, V, TH = any>(object: Of<V> & T,
+      callback: Mapper<Entry<V>, boolean, T, TH>, thisArg?: TH) {
+    return Object.entries(object)
+      .some((item, ind) => callback.call(thisArg, item, ind, object));
   },
 
   getType(item: any) {
@@ -506,7 +530,11 @@ defineProperties(Symbol, {
 
 
 /*
-  CONSTANTS
+   CCCC  OOO  N   N  SSSS TTTTT  AAA  N   N TTTTT  SSSS
+  C     O   O NN  N S       T   A   A NN  N   T   S    
+  C     O   O N N N  SSS    T   AAAAA N N N   T    SSS 
+  C     O   O N  NN     S   T   A   A N  NN   T       S
+   CCCC  OOO  N   N SSSS    T   A   A N   N   T   SSSS
 */
 
 const evalCode = "{const a=JSON.parse(\"\0\"),b=JSON.parse(\"\0\"),c=JSON.parse(\"\0\"),d=Object.getPrototypeOf(async function(){}).constructor,e=JSON.parse(\"\0\"),f=()=>{if(!b)try{return new Function(...a,`return(()=>${e}).call(null,arguments)`).call(this,...arguments)}catch(c){if(c instanceof SyntaxError&&null==b)return new Function(...a,`return(async()=>${e}).call(null,arguments)`).call(this,...arguments);throw c}else return new Function(...a,`return(()=>${e}).call(null,arguments)`).call(this,...arguments)},g=()=>{if(!b)try{return new Function(...a,e).call(this,...arguments)}catch(c){if(c instanceof SyntaxError&&null==b)return new d(...a,e).call(this,...arguments);throw c}else return new d(...a,e).call(this,...arguments)};if(null==c)try{return f()}catch(a){if(a instanceof SyntaxError&&null==c)return g();throw a}else return c?f():g()}";

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -539,7 +539,7 @@ defineProperties(Symbol, {
 
 const evalCode = "{const a=JSON.parse(\"\0\"),b=JSON.parse(\"\0\"),c=JSON.parse(\"\0\"),d=Object.getPrototypeOf(async function(){}).constructor,e=JSON.parse(\"\0\"),f=()=>{if(!b)try{return new Function(...a,`return(()=>${e}).call(null,arguments)`).call(this,...arguments)}catch(c){if(c instanceof SyntaxError&&null==b)return new Function(...a,`return(async()=>${e}).call(null,arguments)`).call(this,...arguments);throw c}else return new Function(...a,`return(()=>${e}).call(null,arguments)`).call(this,...arguments)},g=()=>{if(!b)try{return new Function(...a,e).call(this,...arguments)}catch(c){if(c instanceof SyntaxError&&null==b)return new d(...a,e).call(this,...arguments);throw c}else return new d(...a,e).call(this,...arguments)};if(null==c)try{return f()}catch(a){if(a instanceof SyntaxError&&null==c)return g();throw a}else return c?f():g()}";
 const evalVarsIllegal = ["break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete", "do", "else", "enum", "export", "extends", "false", "finally", "for", "function", "if", "implements", "import", "in", "instanceof", "interface", "let", "new", "null", "packagae", "private", "protected", "public", "return", "static", "super", "switch", "this", "throw", "true", "try", "typeof", "var", "void", "while", "with", "yield"];
-const evalVarsRegEx = /[\p{L}$_][\p{L}\d$_]*/gu;
+const evalVarsRegEx = /[\p{L}$_][\p{L}\d$_]*/u;
 
 
 
@@ -615,7 +615,7 @@ export async function evaluate(code: string | EvaluateOptions,
   let opts: EvaluateOptions;
   if (!options) {
     if (!args) opts = typeof code == "string" ? {"code": code} : code;
-    else opts = {...args, "code": code as string};
+    else opts = {"code": code as string, "arguments": args};
   } else opts = {...options, "arguments": args, "code": code as string};
   Object.forEach(opts.arguments || {}, ([key]) => {
     if (evalVarsIllegal.includes(key) || !evalVarsRegEx.test(key))

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 const assert = require("assert");
-const tools = require("./../out/commonjs-tools");
+const tools = require("./../dist/commonjs-tools");
 
 /**
  * Typescript's tired and true __decorate function.
@@ -134,6 +134,25 @@ describe("String", function() {
 });
 
 describe("bound", function() {
+  it("should update the property descriptor passed or return a new property descriptor with a getter", function() {
+    let descriptor = {
+      "value": function() {
+        return this;
+      },
+      "writable": false
+    };
+
+    let object = {
+      "whatsThis": descriptor.value
+    };
+
+    descriptor = tools.bound(object, "whatsThis", descriptor) || descriptor;
+
+    assert.strictEqual(descriptor.writeable, undefined);
+    assert.strictEqual(descriptor.value, undefined);
+    assert.strictEqual(typeof descriptor.get, "function");
+  });
+
   it("should permanently bind the provided function to it's target", function() {
     let object = {
       func() {

--- a/test/test.js
+++ b/test/test.js
@@ -11,11 +11,29 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
   return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 
+async function assertPromiseReject(promise, error) {
+  class PromiseCompleted extends Error {};
+  try {
+    await promise;
+    throw new PromiseCompleted();
+  } catch (err) {
+    if (err instanceof PromiseCompleted)
+      throw new Error("Promise was completed, but it was expected to be rejected.");
+    if (!(err instanceof error))
+      throw new Error(`Promise rejected with a ${Object.getPrototypeOf(err).constructor.name}, but it was expected to be rejected with a ${error.name}.`);
+  }
+}
+
+async function assertPromiseStrictEqual(promise, result) {
+  assert.strictEqual(await promise, result);
+}
+
 function assertSimilarButNotSame(inputA, inputB) {
   assert(Object.entries(inputA).every(entryA =>
     Object.entries(inputB).find(entryB =>
       entryA[0] == entryB[0] && entryA[1] == entryB[1])));
-  assert(inputA != inputB);
+  if (typeof inputA == "object")
+    assert(inputA != inputB);
 }
 
 describe("Array", function() {
@@ -87,7 +105,67 @@ describe("Object", function() {
     });
   });
 
-  //TODO: Make tests for every, & filter, and finish that line of functions.
+  describe(".every()", function() {
+    it("should work exactly like Array#every upon the provided object's entries", function() {
+      const object1 = {"bob": {"name": "Bob"}, "lisa": {"name": "Lisa"}};
+      const check1 = ([key, value]) => "name" in value && value.name.toLowerCase() == key;
+      assert.strictEqual(Object.every(object1, check1), Object.entries(object1).every(check1));
+    
+      const object2 = {"item1": false, "item2": false, "item3": true};
+      const check2 = ([key, value]) => !value;
+      assert.strictEqual(Object.every(object2, check2), Object.entries(object2).every(check2));
+    });
+  });
+
+  describe(".filter()", function() {
+    it("should work exactly like Array#every upon the provided object's entries", function() {
+      const object1 = {"bob": {"name": "Bob"}, "lisa": {"name": "Lisa"}, "_meta": {"people": 2}};
+      const check1 = ([key]) => key != "_meta";
+      assertSimilarButNotSame(Object.filter(object1, check1), Object.fromEntries(Object.entries(object1).filter(check1)));
+    
+      const object2 = {"item1": false, "item2": false, "item3": true};
+      const check2 = ([key, value]) => !value;
+      assertSimilarButNotSame(Object.filter(object2, check2), Object.fromEntries(Object.entries(object2).filter(check2)));
+    });
+  });
+
+  //TODO: forEach tests.
+
+  describe(".map()", function() {
+    it("should work exactly like Array#every upon the provided object's entries", function() {
+      const object1 = {"bob": {"name": "Bob"}, "lisa": {"name": "Lisa", "employed": true}};
+      const check1 = ([key, value]) => [key, value.employed || false];
+      assertSimilarButNotSame(Object.map(object1, check1), Object.fromEntries(Object.entries(object1).map(check1)));
+    
+      const object2 = {"item1": false, "item2": false, "item3": true};
+      const check2 = ([key, value]) => [key, !value];
+      assertSimilarButNotSame(Object.map(object2, check2), Object.fromEntries(Object.entries(object2).map(check2)));
+    });
+  });
+
+  describe(".reduce()", function() {
+    it("should work exactly like Array#every upon the provided object's entries", function() {
+      const object1 = {"bob": {"name": "Bob"}, "lisa": {"name": "Lisa"}};
+      const check1 = (acc, [key, value]) => (acc.push(value.name), acc);
+      assertSimilarButNotSame(Object.reduce(object1, check1, []), Object.entries(object1).reduce(check1, []));
+    
+      const object2 = {"item1": false, "item2": false, "item3": true};
+      const check2 = (acc, [key, value]) => value ? acc + 1 : acc;
+      assertSimilarButNotSame(Object.reduce(object2, check2, 0), Object.entries(object2).reduce(check2, 0));
+    });
+  });
+
+  describe(".some()", function() {
+    it("should work exactly like Array#every upon the provided object's entries", function() {
+      const object1 = {"bob": {"name": "Bob"}, "lisa": {"name": "Lisa"}, "_meta": {"people": 2}};
+      const check1 = ([key, value]) => !("name" in value);
+      assert.strictEqual(Object.every(object1, check1), Object.entries(object1).every(check1));
+    
+      const object2 = {"item1": false, "item2": false, "item3": true};
+      const check2 = item => !item;
+      assert.strictEqual(Object.some(object2, check2), Object.entries(object2).some(check2));
+    });
+  });
 
   describe(".getType()", function() {
     it('should return the input\'s typeof value if it is not typeof "object"', function() {
@@ -163,5 +241,41 @@ describe("bound", function() {
     __decorate([tools.bound], object, "func", null);
 
     assert.strictEqual(object.func.call({}), object);
+  });
+});
+
+describe("evaluate", function() {
+  it("should evaluate any valid javascript code passed to it", function() {
+    const promises = [
+      assertPromiseStrictEqual(tools.evaluate('"value to be returned"'), "value to be returned"),
+      assertPromiseStrictEqual(tools.evaluate('const item = 19; "not an expression!"'), undefined),
+      assertPromiseStrictEqual(tools.evaluate('const data = 42; return "this should return though"'), "this should return though"),
+      assertPromiseReject(tools.evaluate('def func:\n\tprint("not js code!")'), SyntaxError)
+    ];
+
+    return Promise.all(promises);
+  });
+
+  it("should support passing values to the code as arguments", function() {
+    const object = {};
+    const promises = [
+      assertPromiseStrictEqual(tools.evaluate("num + 1", {"num": 6}), 7),
+      assertPromiseStrictEqual(tools.evaluate("a + b", {"a": 1, "b": 10}), 11),
+      assertPromiseStrictEqual(tools.evaluate("passThrough", {"passThrough": object}), object),
+      assertPromiseReject(tools.evaluate("undefined", {"50notValid": 420, "this": 69}), TypeError)
+    ];
+
+    return Promise.all(promises);
+  });
+
+  it("should have versitile argument arrangements", function() {
+    const promises = [
+      assertPromiseStrictEqual(tools.evaluate('"direct"'), "direct"),
+      assertPromiseStrictEqual(tools.evaluate("`seperate ${arg}`", {"arg": "arguments"}), "seperate arguments"),
+      assertPromiseStrictEqual(tools.evaluate("String(arg)", {"arg": "seperate options"}, {"asynchronous": true}).then(prom => prom), "seperate options"),
+      assertPromiseStrictEqual(tools.evaluate({"code": 'value + " " + value2', "arguments": {"value": "one", "value2": "options object"}}), "one options object")
+    ];
+    
+    return Promise.all(promises);
   });
 });


### PR DESCRIPTION
- Added a GitHub workflow
- Rewrote `gulpfile.js` using ES modules
- Rewrote `evaluate`
- Exported `evaluate`
- Removed `findPairs`
- Added `Object#forEach`
- Added `Object#map`
- Added `Object#reduce`
- Added `Object#sum`
- Added a test for `bound`